### PR TITLE
Change the Product Bundle Identifier to be unique

### DIFF
--- a/PMKMapKit.xcodeproj/project.pbxproj
+++ b/PMKMapKit.xcodeproj/project.pbxproj
@@ -294,7 +294,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.Foundation;
+				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.MapKit;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -345,7 +345,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.Foundation;
+				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.MapKit;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";


### PR DESCRIPTION
Change the product bundle identifier from org.promisekit.foundation to org.promisekit.mapkit in order to prevent errors like "Found bundle at <PATH> with the same identifier (org.promisekit.Foundation) as bundle at <PATH 2>"
