### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
     - {osx_image: xcode9.4,   env: 'PLAT=iOS     SWFT=3.3 DST="OS=11.4,name=iPhone 5s"'}
     - {osx_image: xcode9.4,   env: 'PLAT=tvOS    SWFT=3.3 DST="OS=11.4,name=Apple TV"'}
 
+    - {osx_image: xcode10,    env: 'PLAT=macOS   SWFT=3.4 DST="arch=x86_64"'}
+    - {osx_image: xcode10,    env: 'PLAT=iOS     SWFT=3.4 DST="OS=12.0,name=iPhone SE"'}
+    - {osx_image: xcode10,    env: 'PLAT=tvOS    SWFT=3.4 DST="OS=12.0,name=Apple TV"'}
+
     - {osx_image: xcode9.2,   env: 'PLAT=macOS   SWFT=4.0 DST="arch=x86_64"'}
     - {osx_image: xcode9.2,   env: 'PLAT=iOS     SWFT=4.0 DST="OS=11.2,name=iPhone SE"'}
     - {osx_image: xcode9.2,   env: 'PLAT=tvOS    SWFT=4.0 DST="OS=11.2,name=Apple TV"'}
@@ -25,6 +29,10 @@ matrix:
     - {osx_image: xcode9.4,   env: 'PLAT=iOS     SWFT=4.1 DST="OS=11.4,name=iPhone 5s" TEST=1'}
     - {osx_image: xcode9.3,   env: 'PLAT=tvOS    SWFT=4.1 DST="OS=10.2,name=Apple TV 1080p"'}
     - {osx_image: xcode9.4,   env: 'PLAT=tvOS    SWFT=4.1 DST="OS=11.4,name=Apple TV" TEST=1'}
+
+    - {osx_image: xcode10,    env: 'PLAT=macOS   SWFT=4.2 DST="arch=x86_64"'}
+    - {osx_image: xcode10,    env: 'PLAT=iOS     SWFT=4.2 DST="OS=12.0,name=iPhone SE"'}
+    - {osx_image: xcode10,    env: 'PLAT=tvOS    SWFT=4.2 DST="OS=12.0,name=Apple TV"'}
 cache:
   directories:
   - Carthage

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "CoreCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/PromiseKit" "087b3cf470890ff9ea841212e2f3e285fecf3988"

--- a/Sources/MKDirections+Promise.swift
+++ b/Sources/MKDirections+Promise.swift
@@ -16,21 +16,29 @@ import PromiseKit
 extension MKDirections {
 #if swift(>=4.2)
     /// Begins calculating the requested route information asynchronously.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func calculate() -> Promise<Response> {
         return Promise<Response>(cancellableTask: MKDirectionsTask(self)) { calculate(completionHandler: $0.resolve) }
     }
 
     /// Begins calculating the requested travel-time information asynchronously.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func calculateETA() -> Promise<ETAResponse> {
         return Promise<ETAResponse>(cancellableTask: MKDirectionsTask(self)) { calculateETA(completionHandler: $0.resolve) }
     }
 #else
     /// Begins calculating the requested route information asynchronously.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func calculate() -> Promise<MKDirectionsResponse> {
         return Promise<MKDirectionsResponse>(cancellableTask: MKDirectionsTask(self)) { calculate(completionHandler: $0.resolve) }
     }
 
     /// Begins calculating the requested travel-time information asynchronously.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func calculateETA() -> Promise<MKETAResponse> {
         return Promise<MKETAResponse>(cancellableTask: MKDirectionsTask(self)) { calculateETA(completionHandler: $0.resolve) }
     }
@@ -53,30 +61,4 @@ private class MKDirectionsTask: CancellableTask {
     var isCancelled: Bool {
         return cancelAttempted && !directions.isCalculating
     }
-}
-
-//////////////////////////////////////////////////////////// Cancellable wrappers
-
-extension MKDirections {
-#if swift(>=4.2)
-    /// Begins calculating the requested route information asynchronously.
-    public func cancellableCalculate() -> CancellablePromise<Response> {
-        return cancellable(calculate())
-    }
-
-    /// Begins calculating the requested travel-time information asynchronously.
-    public func cancellableCalculateETA() -> CancellablePromise<ETAResponse> {
-        return cancellable(calculateETA())
-    }
-#else
-    /// Begins calculating the requested route information asynchronously.
-    public func cancellableCalculate() -> CancellablePromise<MKDirectionsResponse> {
-        return cancellable(calculate())
-    }
-
-    /// Begins calculating the requested travel-time information asynchronously.
-    public func cancellableCalculateETA() -> CancellablePromise<MKETAResponse> {
-        return cancellable(calculateETA())
-    }
-#endif
 }

--- a/Sources/MKDirections+Promise.swift
+++ b/Sources/MKDirections+Promise.swift
@@ -14,13 +14,69 @@ import PromiseKit
     import PromiseKit
 */
 extension MKDirections {
+#if swift(>=4.2)
+    /// Begins calculating the requested route information asynchronously.
+    public func calculate() -> Promise<Response> {
+        return Promise<Response>(cancellableTask: MKDirectionsTask(self)) { calculate(completionHandler: $0.resolve) }
+    }
+
+    /// Begins calculating the requested travel-time information asynchronously.
+    public func calculateETA() -> Promise<ETAResponse> {
+        return Promise<ETAResponse>(cancellableTask: MKDirectionsTask(self)) { calculateETA(completionHandler: $0.resolve) }
+    }
+#else
     /// Begins calculating the requested route information asynchronously.
     public func calculate() -> Promise<MKDirectionsResponse> {
-        return Promise { calculate(completionHandler: $0.resolve) }
+        return Promise<MKDirectionsResponse>(cancellableTask: MKDirectionsTask(self)) { calculate(completionHandler: $0.resolve) }
     }
 
     /// Begins calculating the requested travel-time information asynchronously.
     public func calculateETA() -> Promise<MKETAResponse> {
-        return Promise { calculateETA(completionHandler: $0.resolve) }
+        return Promise<MKETAResponse>(cancellableTask: MKDirectionsTask(self)) { calculateETA(completionHandler: $0.resolve) }
     }
+#endif
+}
+
+private class MKDirectionsTask: CancellableTask {
+    let directions: MKDirections
+    var cancelAttempted = false
+    
+    init(_ directions: MKDirections) {
+        self.directions = directions
+    }
+    
+    func cancel() {
+        directions.cancel()
+        cancelAttempted = true
+    }
+    
+    var isCancelled: Bool {
+        return cancelAttempted && !directions.isCalculating
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellable wrappers
+
+extension MKDirections {
+#if swift(>=4.2)
+    /// Begins calculating the requested route information asynchronously.
+    public func cancellableCalculate() -> CancellablePromise<Response> {
+        return cancellable(calculate())
+    }
+
+    /// Begins calculating the requested travel-time information asynchronously.
+    public func cancellableCalculateETA() -> CancellablePromise<ETAResponse> {
+        return cancellable(calculateETA())
+    }
+#else
+    /// Begins calculating the requested route information asynchronously.
+    public func cancellableCalculate() -> CancellablePromise<MKDirectionsResponse> {
+        return cancellable(calculate())
+    }
+
+    /// Begins calculating the requested travel-time information asynchronously.
+    public func cancellableCalculateETA() -> CancellablePromise<MKETAResponse> {
+        return cancellable(calculateETA())
+    }
+#endif
 }

--- a/Sources/MKMapSnapshotter+Promise.swift
+++ b/Sources/MKMapSnapshotter+Promise.swift
@@ -16,11 +16,15 @@ import PromiseKit
 extension MKMapSnapshotter {
 #if swift(>=4.2)
     /// Starts generating the snapshot using the options set in this object.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func start() -> Promise<Snapshot> {
         return Promise<Snapshot>(cancellableTask: MKMapSnapshotterTask(self)) { start(completionHandler: $0.resolve) }
     }
 #else
     /// Starts generating the snapshot using the options set in this object.
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     public func start() -> Promise<MKMapSnapshot> {
         return Promise<MKMapSnapshot>(cancellableTask: MKMapSnapshotterTask(self)) { start(completionHandler: $0.resolve) }
     }
@@ -43,20 +47,4 @@ private class MKMapSnapshotterTask: CancellableTask {
     var isCancelled: Bool {
         return cancelAttempted && !snapshotter.isLoading
     }
-}
-
-//////////////////////////////////////////////////////////// Cancellable wrapper
-
-extension MKMapSnapshotter {
-#if swift(>=4.2)
-    /// Starts generating the snapshot using the options set in this object.
-    public func cancellableStart() -> CancellablePromise<Snapshot> {
-        return cancellable(start())
-    }
-#else
-    /// Starts generating the snapshot using the options set in this object.
-    public func cancellableStart() -> CancellablePromise<MKMapSnapshot> {
-        return cancellable(start())
-    }
-#endif
 }

--- a/Sources/MKMapSnapshotter+Promise.swift
+++ b/Sources/MKMapSnapshotter+Promise.swift
@@ -14,8 +14,49 @@ import PromiseKit
     import PromiseKit
 */
 extension MKMapSnapshotter {
+#if swift(>=4.2)
+    /// Starts generating the snapshot using the options set in this object.
+    public func start() -> Promise<Snapshot> {
+        return Promise<Snapshot>(cancellableTask: MKMapSnapshotterTask(self)) { start(completionHandler: $0.resolve) }
+    }
+#else
     /// Starts generating the snapshot using the options set in this object.
     public func start() -> Promise<MKMapSnapshot> {
-        return Promise { start(completionHandler: $0.resolve) }
+        return Promise<MKMapSnapshot>(cancellableTask: MKMapSnapshotterTask(self)) { start(completionHandler: $0.resolve) }
     }
+#endif
+}
+
+private class MKMapSnapshotterTask: CancellableTask {
+    let snapshotter: MKMapSnapshotter
+    var cancelAttempted = false
+    
+    init(_ snapshotter: MKMapSnapshotter) {
+        self.snapshotter = snapshotter
+    }
+    
+    func cancel() {
+        snapshotter.cancel()
+        cancelAttempted = true
+    }
+    
+    var isCancelled: Bool {
+        return cancelAttempted && !snapshotter.isLoading
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellable wrapper
+
+extension MKMapSnapshotter {
+#if swift(>=4.2)
+    /// Starts generating the snapshot using the options set in this object.
+    public func cancellableStart() -> CancellablePromise<Snapshot> {
+        return cancellable(start())
+    }
+#else
+    /// Starts generating the snapshot using the options set in this object.
+    public func cancellableStart() -> CancellablePromise<MKMapSnapshot> {
+        return cancellable(start())
+    }
+#endif
 }

--- a/Tests/TestMapKit.swift
+++ b/Tests/TestMapKit.swift
@@ -77,7 +77,7 @@ extension Test_MKDirections_Swift {
         let rq = MKDirectionsRequest()
         let directions = MockDirections(request: rq)
 
-        directions.cancellableCalculate().done { _ in
+        cancellable(directions.calculate()).done { _ in
             XCTFail()
         }.catch(policy: .allErrors) {
             $0.isCancelled ? ex.fulfill() : XCTFail()
@@ -97,7 +97,7 @@ extension Test_MKDirections_Swift {
         }
 
         let rq = MKDirectionsRequest()
-        MockDirections(request: rq).cancellableCalculateETA().done { _ in
+        cancellable(MockDirections(request: rq).calculateETA()).done { _ in
             XCTFail()
         }.catch(policy: .allErrors) {
             $0.isCancelled ? ex.fulfill() : XCTFail()
@@ -119,7 +119,7 @@ extension Test_MKSnapshotter_Swift {
         }
 
         let snapshotter = MockSnapshotter()
-        snapshotter.cancellableStart().done { _ in
+        cancellable(snapshotter.start()).done { _ in
             XCTFail()
         }.catch(policy: .allErrors) {
             $0.isCancelled ? ex.fulfill() : XCTFail()

--- a/Tests/TestMapKit.swift
+++ b/Tests/TestMapKit.swift
@@ -61,3 +61,70 @@ class Test_MKSnapshotter_Swift: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension Test_MKDirections_Swift {
+    func test_cancel_directions_response() {
+        let ex = expectation(description: "")
+
+        class MockDirections: MKDirections {
+            override func calculate(completionHandler: @escaping MKDirectionsHandler) {
+                completionHandler(MKDirectionsResponse(), nil)
+            }
+        }
+
+        let rq = MKDirectionsRequest()
+        let directions = MockDirections(request: rq)
+
+        directions.cancellableCalculate().done { _ in
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+
+    func test_cancel_ETA_response() {
+        let ex = expectation(description: "")
+
+        class MockDirections: MKDirections {
+            override func calculateETA(completionHandler: @escaping MKETAHandler) {
+                completionHandler(MKETAResponse(), nil)
+            }
+        }
+
+        let rq = MKDirectionsRequest()
+        MockDirections(request: rq).cancellableCalculateETA().done { _ in
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+}
+
+extension Test_MKSnapshotter_Swift {
+    func test_cancel() {
+        let ex = expectation(description: "")
+
+        class MockSnapshotter: MKMapSnapshotter {
+            override func start(completionHandler: @escaping MKMapSnapshotCompletionHandler) {
+                completionHandler(MKMapSnapshot(), nil)
+            }
+        }
+
+        let snapshotter = MockSnapshotter()
+        snapshotter.cancellableStart().done { _ in
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
