### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,3 @@
 github "mxcl/PromiseKit" ~> 6.0
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKMapKit.xcodeproj/project.pbxproj
+++ b/PMKMapKit.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 			);
 			inputPaths = (
 				PromiseKit,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Sources/MKDirections+Promise.swift
+++ b/Sources/MKDirections+Promise.swift
@@ -1,5 +1,6 @@
 import MapKit
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 
@@ -22,5 +23,37 @@ extension MKDirections {
     /// Begins calculating the requested travel-time information asynchronously.
     public func calculateETA() -> Promise<MKETAResponse> {
         return Promise { calculateETA(completionHandler: $0.resolve) }
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+fileprivate class MKDirectionsTask: CancellableTask {
+    let directions: MKDirections
+    var cancelAttempted = false
+    
+    init(_ directions: MKDirections) {
+        self.directions = directions
+    }
+    
+    func cancel() {
+        directions.cancel()
+        cancelAttempted = true
+    }
+    
+    var isCancelled: Bool {
+        return cancelAttempted && !directions.isCalculating
+    }
+}
+
+extension MKDirections {
+    /// Begins calculating the requested route information asynchronously.
+    public func calculateCC() -> CancellablePromise<MKDirectionsResponse> {
+        return CancellablePromise(task: MKDirectionsTask(self)) { calculate(completionHandler: $0.resolve) }
+    }
+
+    /// Begins calculating the requested travel-time information asynchronously.
+    public func calculateETACC() -> CancellablePromise<MKETAResponse> {
+        return CancellablePromise(task: MKDirectionsTask(self)) { calculateETA(completionHandler: $0.resolve) }
     }
 }

--- a/Sources/MKMapSnapshotter+Promise.swift
+++ b/Sources/MKMapSnapshotter+Promise.swift
@@ -1,5 +1,6 @@
 import MapKit
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 
@@ -17,5 +18,32 @@ extension MKMapSnapshotter {
     /// Starts generating the snapshot using the options set in this object.
     public func start() -> Promise<MKMapSnapshot> {
         return Promise { start(completionHandler: $0.resolve) }
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+fileprivate class MKMapSnapshotterTask: CancellableTask {
+    let snapshotter: MKMapSnapshotter
+    var cancelAttempted = false
+    
+    init(_ snapshotter: MKMapSnapshotter) {
+        self.snapshotter = snapshotter
+    }
+    
+    func cancel() {
+        snapshotter.cancel()
+        cancelAttempted = true
+    }
+    
+    var isCancelled: Bool {
+        return cancelAttempted && !snapshotter.isLoading
+    }
+}
+
+extension MKMapSnapshotter {
+    /// Starts generating the snapshot using the options set in this object.
+    public func startCC() -> CancellablePromise<MKMapSnapshot> {
+        return CancellablePromise(task: MKMapSnapshotterTask(self)) { start(completionHandler: $0.resolve) }
     }
 }


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
